### PR TITLE
maelstrom: make the API consistent by returning Message in all "send" methods

### DIFF
--- a/cmd/broadcast/main.go
+++ b/cmd/broadcast/main.go
@@ -64,7 +64,7 @@ func (b *broadcaster) HandleBroadcast(n *maelstrom.Node, msg maelstrom.Message) 
 
 	b.messages = append(b.messages, body["message"])
 
-	if err := n.Reply(msg, "broadcast_ok", nil); err != nil {
+	if _, err := n.Reply(msg, "broadcast_ok", nil); err != nil {
 		log.Printf("error: broadcast: reply: %v", err)
 		return
 	}
@@ -85,7 +85,7 @@ func (b *broadcaster) HandleRead(n *maelstrom.Node, msg maelstrom.Message) {
 	payload := map[string][]json.RawMessage{
 		"messages": b.messages,
 	}
-	if err := n.Reply(msg, "read_ok", payload); err != nil {
+	if _, err := n.Reply(msg, "read_ok", payload); err != nil {
 		log.Printf("error: read: reply: %v", err)
 	}
 }
@@ -109,7 +109,7 @@ func (b *broadcaster) HandleTopology(n *maelstrom.Node, msg maelstrom.Message) {
 	}
 	b.neighbors = neighbors
 
-	if err := n.Reply(msg, "topology_ok", nil); err != nil {
+	if _, err := n.Reply(msg, "topology_ok", nil); err != nil {
 		log.Printf("error: topology: reply: %v", err)
 	}
 }
@@ -125,7 +125,7 @@ func (b *broadcaster) HandleSync(n *maelstrom.Node, msg maelstrom.Message) {
 	}
 	b.messages = append(b.messages, payload.Message)
 
-	if err := n.Reply(msg, "sync_ok", nil); err != nil {
+	if _, err := n.Reply(msg, "sync_ok", nil); err != nil {
 		log.Printf("error: sync: reply: %v", err)
 	}
 

--- a/cmd/echo/main.go
+++ b/cmd/echo/main.go
@@ -15,7 +15,7 @@ import (
 func main() {
 	n := maelstrom.NewNode(os.Stdin, os.Stdout)
 	n.HandleFunc("echo", func(n *maelstrom.Node, req maelstrom.Message) {
-		if err := n.Reply(req, "echo_ok", req.Body); err != nil {
+		if _, err := n.Reply(req, "echo_ok", req.Body); err != nil {
 			log.Printf("error: echo: reply: %v", err)
 		}
 	})

--- a/cmd/uid/main.go
+++ b/cmd/uid/main.go
@@ -71,7 +71,7 @@ func (gen *uidGenerator) ServeMessage(n *maelstrom.Node, msg maelstrom.Message) 
 	}
 
 	payload := map[string]string{"id": uid}
-	if err := n.Reply(msg, "generate_ok", payload); err != nil {
+	if _, err := n.Reply(msg, "generate_ok", payload); err != nil {
 		log.Printf("error: generate: reply: %v", err)
 	}
 }

--- a/maelstrom_test.go
+++ b/maelstrom_test.go
@@ -401,7 +401,7 @@ func TestNode_Send(t *testing.T) {
 	n.HandleFunc("t1", func(n *Node, _ Message) {
 		defer wg.Done()
 
-		if err := n.Send("c1", "t1_ok", map[string]string{"k1": "v1"}); err != nil {
+		if _, err := n.Send("c1", "t1_ok", map[string]string{"k1": "v1"}); err != nil {
 			t.Errorf("handler: send error: %v", err)
 		}
 	})
@@ -426,7 +426,7 @@ func TestNode_Send_error(t *testing.T) {
 
 	n := NewNode(stdin, stdout)
 
-	if err := n.Send("c1", "t1", "invalid"); err == nil {
+	if _, err := n.Send("c1", "t1", "invalid"); err == nil {
 		t.Error("expected send error when payload is invalid")
 	}
 }
@@ -451,7 +451,7 @@ func TestNode_Reply(t *testing.T) {
 	n.HandleFunc("t1", func(n *Node, msg Message) {
 		defer wg.Done()
 
-		if err := n.Reply(msg, "t1_ok", map[string]string{"k1": "v1"}); err != nil {
+		if _, err := n.Reply(msg, "t1_ok", map[string]string{"k1": "v1"}); err != nil {
 			t.Errorf("handler: reply error: %v", err)
 		}
 	})
@@ -476,7 +476,7 @@ func TestNode_Reply_error(t *testing.T) {
 
 	n := NewNode(stdin, stdout)
 
-	if err := n.Send("c1", "t1", "invalid"); err == nil {
+	if _, err := n.Send("c1", "t1", "invalid"); err == nil {
 		t.Error("expected send error when payload is invalid")
 	}
 
@@ -485,7 +485,7 @@ func TestNode_Reply_error(t *testing.T) {
 		Dest: "n1",
 		Body: json.RawMessage(`{"type": "t1", "msg_id": 123}`),
 	}
-	if err := n.Reply(validMsg, "t1_ok", "invalid"); err == nil {
+	if _, err := n.Reply(validMsg, "t1_ok", "invalid"); err == nil {
 		t.Error("expected send error when payload is invalid")
 	}
 
@@ -494,7 +494,7 @@ func TestNode_Reply_error(t *testing.T) {
 		Dest: "n1",
 		Body: json.RawMessage(`{`),
 	}
-	if err := n.Reply(malformedMsg, "t1_ok", "invalid"); err == nil {
+	if _, err := n.Reply(malformedMsg, "t1_ok", "invalid"); err == nil {
 		t.Error("expected send error when payload is invalid")
 	}
 }
@@ -522,7 +522,7 @@ func TestNode_RPC(t *testing.T) {
 	respHandler := func(n *Node, _ Message) {
 		defer wg.Done()
 
-		if err := n.Send("c1", "t3", nil); err != nil {
+		if _, err := n.Send("c1", "t3", nil); err != nil {
 			t.Errorf("respHandler: send error: %v", err)
 		}
 	}

--- a/retrier.go
+++ b/retrier.go
@@ -10,7 +10,7 @@ import (
 	"time"
 )
 
-// A Retrier resends the requests waiting for response.
+// A Retrier resends requests.
 type Retrier struct {
 	// node is the cluster node tracking the requests.
 	node *Node


### PR DESCRIPTION
This pull request changes the methods `*Node.Send` and `*Node.Reply`
to also return the `Message` that has been sent. So, it is possible to
retry them.