### PR TITLE
retrier: accept context in `*Retrier.Retry` method

### DIFF
--- a/cmd/broadcast/main.go
+++ b/cmd/broadcast/main.go
@@ -6,6 +6,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -47,7 +48,7 @@ func newBroadcaster(node *maelstrom.Node, retrier *maelstrom.Retrier) *broadcast
 		retrier: retrier,
 	}
 	if retrier != nil {
-		go retrier.Retry()
+		go retrier.Retry(context.TODO())
 	}
 	return b
 }

--- a/cmd/uid/main.go
+++ b/cmd/uid/main.go
@@ -19,19 +19,15 @@ import (
 
 func main() {
 	n := maelstrom.NewNode(os.Stdin, os.Stdout)
-	n.Handle("generate", newUIDGenerator())
+	n.Handle("generate", &uidGenerator{})
 	log.Fatalln(n.Serve())
 }
 
 type uidGenerator struct {
-	mu          *sync.Mutex
+	mu          sync.Mutex
 	initialized bool
 	nodeNum     uint64
 	ctr         uint64
-}
-
-func newUIDGenerator() *uidGenerator {
-	return &uidGenerator{mu: new(sync.Mutex)}
 }
 
 func (gen *uidGenerator) uid(nodeID string) (string, error) {

--- a/maelstrom.go
+++ b/maelstrom.go
@@ -134,7 +134,7 @@ type Node struct {
 	msgID atomic.Uint64
 
 	// mu protects the fields below.
-	mu *sync.Mutex
+	mu sync.Mutex
 
 	// enc is used to encode Maelstrom messages.
 	enc *json.Encoder
@@ -149,7 +149,6 @@ func NewNode(r io.Reader, w io.Writer) *Node {
 	return &Node{
 		handlers:     make(map[string]Handler),
 		scanner:      bufio.NewScanner(r),
-		mu:           new(sync.Mutex),
 		enc:          json.NewEncoder(w),
 		respHandlers: make(map[uint64]Handler),
 	}

--- a/retrier.go
+++ b/retrier.go
@@ -23,7 +23,7 @@ type Retrier struct {
 	retryTime time.Duration
 
 	// mu protects the fields below.
-	mu *sync.Mutex
+	mu sync.Mutex
 
 	// pending contains the requests waiting for response.
 	pending map[uint64]pendingReq
@@ -46,7 +46,6 @@ func NewRetrier(node *Node, wt, rt time.Duration) *Retrier {
 		node:      node,
 		waitTime:  wt,
 		retryTime: rt,
-		mu:        new(sync.Mutex),
 		pending:   make(map[uint64]pendingReq),
 	}
 }

--- a/retrier.go
+++ b/retrier.go
@@ -3,6 +3,7 @@
 package maelstrom
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log"
@@ -51,12 +52,16 @@ func NewRetrier(node *Node, wt, rt time.Duration) *Retrier {
 }
 
 // Retry starts handling pending requests.
-func (r *Retrier) Retry() {
+func (r *Retrier) Retry(ctx context.Context) {
 	for {
-		if err := r.retryReqs(); err != nil {
-			log.Printf("maelstrom: retry error: %v", err)
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(r.retryTime):
+			if err := r.retryReqs(); err != nil {
+				log.Printf("maelstrom: retry error: %v", err)
+			}
 		}
-		time.Sleep(r.retryTime)
 	}
 }
 

--- a/retrier_test.go
+++ b/retrier_test.go
@@ -4,8 +4,10 @@ package maelstrom
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -33,15 +35,17 @@ func TestRetrier(t *testing.T) {
 	node := NewNode(stdin, stdout)
 	retrier := NewRetrier(node, 500*time.Millisecond, 250*time.Millisecond)
 
-	cont := make(chan bool)
-	done := make(chan bool)
+	var wg sync.WaitGroup
 
 	respHandler := func(_ *Node, msg Message) {
+		defer wg.Done()
 		if err := retrier.Remove(msg); err != nil {
 			t.Errorf("response handler: retrier remove error: %v", err)
 		}
-		done <- true
 	}
+
+	cont := make(chan bool)
+
 	handler := func(n *Node, _ Message) {
 		msg, err := n.RPC("c1", "t2", map[string]string{"k1": "v1"}, HandlerFunc(respHandler))
 		if err != nil {
@@ -65,11 +69,19 @@ func TestRetrier(t *testing.T) {
 
 	node.HandleFunc("t1", handler)
 
-	go retrier.Retry()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		retrier.Retry(ctx)
+	}()
 	if err := node.Serve(); err != nil {
 		t.Fatalf("serve error: %v", err)
 	}
-	<-done
+	cancel()
+	wg.Wait()
 
 	if len(node.respHandlers) > 0 {
 		t.Errorf("unexpected number of response handlers: %v", len(node.respHandlers))

--- a/retrier_test.go
+++ b/retrier_test.go
@@ -28,7 +28,7 @@ func TestRetrier(t *testing.T) {
 	}
 
 	stdin := bytes.NewBufferString(input)
-	stdout := new(bytes.Buffer)
+	stdout := &bytes.Buffer{}
 
 	node := NewNode(stdin, stdout)
 	retrier := NewRetrier(node, 500*time.Millisecond, 250*time.Millisecond)


### PR DESCRIPTION
This pull requests modifies the `*Retrier.Retry` method to accept a
context. It also fixes several coding style issues.