### PR TITLE
maelstrom: wait for all handlers before successfully returning from *Node.Serve

### DIFF
--- a/retrier_test.go
+++ b/retrier_test.go
@@ -76,7 +76,6 @@ func TestRetrier(t *testing.T) {
 
 	go func() {
 		defer wg.Done()
-
 		retrier.Retry(ctx)
 	}()
 


### PR DESCRIPTION
This pull request changes `*Node.Serve` so it waits for all message
handlers to finish before successfully returning.